### PR TITLE
fix: change module format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.0.0-beta.2 (2023-02-24)
+
+
+### Features
+
+* **decode:** :sparkles: ([bb4a263](https://github.com/stevebel/png/commit/bb4a2637539c44335e82cd067774aac50bec4d74))
+* **decode:** :sparkles: crc32 and parse IEND ([43f52a4](https://github.com/stevebel/png/commit/43f52a4b697aab48d9f16bdac09b74a610aef1e1))
+* **decode:** :sparkles: support bit depth 1 ([b218092](https://github.com/stevebel/png/commit/b218092fea37a0131623f2d69f5dface565bf5ca))
+* **decode:** :sparkles: support bit depth 1 ([#2](https://github.com/stevebel/png/issues/2)) ([7016d2d](https://github.com/stevebel/png/commit/7016d2db2f7cda6badadf26c500cf1f4ca2ebaf6))
+* **decode:** :sparkles: support bit depth 16, filter 1, filter 2 and re ([25e5793](https://github.com/stevebel/png/commit/25e5793cb9c5dae83fcbdd95a71daefbba5da7f0))
+* **decode:** :sparkles: support bit depth 4 ([afd8b1f](https://github.com/stevebel/png/commit/afd8b1ffa56b11ec0c4de202d4a5cca4e4689c10))
+* **decode:** :sparkles: support bit depth 8 ([1f3d999](https://github.com/stevebel/png/commit/1f3d99901eec98794a2d33d6ff148fa68e31616d))
+* **decode:** :sparkles: support bKGD chunk ([6a2b447](https://github.com/stevebel/png/commit/6a2b447d5ae5e185f7a5c8013a0caaed63060eb1))
+* **decode:** :sparkles: support cHRM ([6735885](https://github.com/stevebel/png/commit/6735885221037b3d530f78d6ad9eaf545847fb77))
+* **decode:** :sparkles: support color type 2 ([e927a0e](https://github.com/stevebel/png/commit/e927a0edb6d48c29a7dab8d7adc45f31c72a1ed8))
+* **decode:** :sparkles: support color type 6 ([7710aec](https://github.com/stevebel/png/commit/7710aeceecdda3d451193edee13747d559cba663))
+* **decode:** :sparkles: support colorType 3 and depth 2 ([1eebacd](https://github.com/stevebel/png/commit/1eebacd0e96ae27a72caeefe2090b6c293316b15))
+* **decode:** :sparkles: support filter 3 ([9131680](https://github.com/stevebel/png/commit/9131680c080fd9179bf0233a339c5076d1a26062))
+* **decode:** :sparkles: support filter 4 and color type 4 ([88b4950](https://github.com/stevebel/png/commit/88b4950546e2acbbf4d399ec7775a017ab163390))
+* **decode:** :sparkles: support gAMA ([33b7385](https://github.com/stevebel/png/commit/33b7385065970340afe78d539451527c812a628a))
+* **decode:** :sparkles: support hIST ([4d78118](https://github.com/stevebel/png/commit/4d781183f943c3a685bb7aac780772c0054b2d67))
+* **decode:** :sparkles: support iCCP ([99ee169](https://github.com/stevebel/png/commit/99ee169270ef5ccd427f5a7e0b3f42480e162f12))
+* **decode:** :sparkles: support interlace ([1bbf6eb](https://github.com/stevebel/png/commit/1bbf6ebac0bd22652f2af7dc31770daa1944ad9e))
+* **decode:** :sparkles: support iTXt ([6b867cc](https://github.com/stevebel/png/commit/6b867ccdc3ead3c54432ab85be48deb857b301ba))
+* **decode:** :sparkles: support pHYs ([7b0bf80](https://github.com/stevebel/png/commit/7b0bf802fbe863d608180ed4633ea257573db8bb))
+* **decode:** :sparkles: support sBIT ([5cef76d](https://github.com/stevebel/png/commit/5cef76d14c731c2625b4972d0444a07dd8f6284b))
+* **decode:** :sparkles: support sPLT ([c58a478](https://github.com/stevebel/png/commit/c58a47840b23a9bb7f18c4f3885c2746c38a045a))
+* **decode:** :sparkles: support sRGB ([77edb37](https://github.com/stevebel/png/commit/77edb37215c0dc72f31377c2a6ef7585fa405504))
+* **decode:** :sparkles: support tEXt ([e0f49b6](https://github.com/stevebel/png/commit/e0f49b6109eabd8a42e69af742cc2a805bfd6106))
+* **decode:** :sparkles: support tIME ([fc6df50](https://github.com/stevebel/png/commit/fc6df50f6754c1776257a4e6287d4c360167c359))
+* **decode:** :sparkles: support tRNS ([d32e449](https://github.com/stevebel/png/commit/d32e4495b50bfe9065390499a71e6b2f212559ad))
+* **decode:** :sparkles: support zTXt ([2a348fe](https://github.com/stevebel/png/commit/2a348fea892b727048f08072242c1e51229ac58e))
+* **encode:** :sparkles: support bit depth 2 ([bb234bd](https://github.com/stevebel/png/commit/bb234bd683ac691bb91bb2e06bce626a51790d62))
+* **encode:** :sparkles: support bKGD ([6514fc4](https://github.com/stevebel/png/commit/6514fc4f8daed41bd6b0ad8301d76b6330e11aed))
+* **encode:** :sparkles: support cHRM ([ad1c959](https://github.com/stevebel/png/commit/ad1c95940b261e038847cb2cfd6bf4ab31b441b7))
+* **encode:** :sparkles: support filter 0, 1, 2, 3, 4 ([3087f67](https://github.com/stevebel/png/commit/3087f679983515f41bc255490e790a5942fe5ed5))
+* **encode:** :sparkles: support gMMA and filter 1 ([f379167](https://github.com/stevebel/png/commit/f3791675148e8e89234f8b1b5c077627fb82f5b0))
+* **encode:** :sparkles: support hIST ([fd6e9a7](https://github.com/stevebel/png/commit/fd6e9a76d38c4413acaebcd69b0f9296fccbaf0d))
+* **encode:** :sparkles: support iCCP ([d689c00](https://github.com/stevebel/png/commit/d689c00eb11c25f7f3554dae3686a9da8691ce00))
+* **encode:** :sparkles: support IDAT, color type 3 and filter 0 ([506c2a2](https://github.com/stevebel/png/commit/506c2a2c1dfa983de6af131c7973c8558eefeafd))
+* **encode:** :sparkles: support IHDR ([9e95e10](https://github.com/stevebel/png/commit/9e95e10bab7a61b1bfa3543c5422823cc0c2e524))
+* **encode:** :sparkles: support interlace ([496a332](https://github.com/stevebel/png/commit/496a3325cd18dab639b0ee6366d64ac9aa6efa9e))
+* **encode:** :sparkles: support iTXt ([375c749](https://github.com/stevebel/png/commit/375c7497ff51ec0ac206885490b85cebce8b0db8))
+* **encode:** :sparkles: support PLTE ([e14dca8](https://github.com/stevebel/png/commit/e14dca81f7854c3601756ef31c4669491d9bfa4b))
+* **encode:** :sparkles: support pYHs ([e0473f0](https://github.com/stevebel/png/commit/e0473f0afc2ed2ce3426f98c433b1b48afebd61b))
+* **encode:** :sparkles: support signature ([ebecb94](https://github.com/stevebel/png/commit/ebecb94b73361918eeaf398f599677050ddb3b3b))
+* **encode:** :sparkles: support sPLT ([56a48a7](https://github.com/stevebel/png/commit/56a48a7752eb7adea21f905df89db0fd50e9b606))
+* **encode:** :sparkles: support sRGB ([0e3f570](https://github.com/stevebel/png/commit/0e3f570ba609a625fbdc31442de76fdcb7e0803c))
+* **encode:** :sparkles: support tEXt ([3dc0e2e](https://github.com/stevebel/png/commit/3dc0e2eb64633108a8c31d06575eaf3937342a8d))
+* **encode:** :sparkles: support tIME ([613dfdd](https://github.com/stevebel/png/commit/613dfddb9e258baf44f9f6544308fb94db7cd04c))
+* **encode:** :sparkles: support tRNS with color type 0 ([e53c063](https://github.com/stevebel/png/commit/e53c063a4e90608170d89437fd62b154c5f78973))
+* **encode:** :sparkles: support tRNS with color type 2 ([1bf65a4](https://github.com/stevebel/png/commit/1bf65a40fbfa27c921f25fa54349244c4173b276))
+* **encode:** :sparkles: support zTXt ([2b6fbe8](https://github.com/stevebel/png/commit/2b6fbe8b937523d9f4835b6f97dba7e8eede959a))
+* **iccp:** :sparkles: update icc profile typings ([f6de54a](https://github.com/stevebel/png/commit/f6de54a6632ebd2a7ad44b1277ab794d43130ae5))
+* **init:** :sparkles: ([6f2afb4](https://github.com/stevebel/png/commit/6f2afb47c53ee69a2a6cc4e7178b74d5fe2a102f))
+* **parse idat:** :sparkles: ([71041b4](https://github.com/stevebel/png/commit/71041b4c675a72735849082c570d0ef7f32937a1))
+* **png:** :sparkles: implement parsers ([98fa580](https://github.com/stevebel/png/commit/98fa5804196ba57dbdcdda14e548fd744f28ec8d))
+
+
+### Bug Fixes
+
+* change module format to esnext to better support browser usage ([15cda31](https://github.com/stevebel/png/commit/15cda316e4114793e5fbd90aacca038123e6b0eb))
+* **encode:** :bug: fix filter 1, 3 and 4 ([cae9672](https://github.com/stevebel/png/commit/cae9672706c18f04b9c219845373ea510e01a320))
+
 ## [1.0.0-beta.1](https://github.com/stevebel/png/compare/v1.1.0-beta.1...v1.0.0-beta.1) (2023-02-24)
 
 ## [1.1.0-beta.1](https://github.com/stevebel/png/compare/v1.1.0-beta.0...v1.1.0-beta.1) (2023-02-24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stevebel/png",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "🖼A full-featured PNG decoder and encoder.",
   "keywords": [
     "png",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "./lib",
     "strict": true


### PR DESCRIPTION
Was having issues when importing the library in a browser app due to the module being packed in CommonJS format. ESNext should support both server and client-side use